### PR TITLE
fix(infra/docker): align backend image with package layout

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,11 +9,11 @@ COPY requirements.txt .
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy application code
-COPY . .
+# Copy ONLY backend folder into /app/backend
+COPY backend/ /app/backend/
 
 # Expose port
 EXPOSE 8000
 
-# Command to run the application
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Run the FastAPI app
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,33 @@
 services:
   frontend:
     build:
-      context: . # set to root to access the requirements.txt
+      context: . # root so Dockerfile sees project files
       dockerfile: frontend/Dockerfile
     ports:
       - '3000:80'
     depends_on:
       - backend
+    # volumes:
+    #   - ./frontend:/app/frontend
 
   backend:
     build:
-      context: . # set to root to access the requirements.txt
+      context: .
       dockerfile: backend/Dockerfile
     ports:
       - '8000:8000'
     environment:
-      - TESTING=true
       - PYTHONPATH=/app
+      - TESTING=true
     volumes:
-      - ./backend:/app
+      - ./backend:/app/backend
     working_dir: /app
+    command: uvicorn backend.main:app --host 0.0.0.0 --port 8000
 
   test-runner:
     build:
-      context: . # context should be root to access all services
-      dockerfile: tests/Dockerfile.test # specify the test Dockerfile
+      context: .
+      dockerfile: tests/Dockerfile.test
     depends_on:
       - backend
       - frontend
@@ -33,4 +36,5 @@ services:
     volumes:
       - ./backend:/app/backend
       - ./frontend:/app/frontend
-    command: pytest /app/backend/tests -v
+    working_dir: /app/backend
+    command: pytest tests -v


### PR DESCRIPTION
Update backend Dockerfile to copy the backend/ package into /app/backend and run uvicorn using backend.main:app. Adjust docker-compose backend service to mount ./backend to /app/backend, set PYTHONPATH=/app, and keep imports like 'from backend.routers import ...' working consistently in both tests and the Docker container.